### PR TITLE
Update big_transfer_tf2 notebook.

### DIFF
--- a/colabs/big_transfer_tf2.ipynb
+++ b/colabs/big_transfer_tf2.ipynb
@@ -323,9 +323,11 @@
         "\n",
         "In this colab, we will show you how to load one of our BiT models (a ResNet50 trained on ImageNet-21k), use it out-of-the-box and fine-tune it on a dataset of flowers.\n",
         "\n",
-        "This colab accompanies our [the TensorFlow blog post]() (TODO: link) and is based on the [BigTransfer paper](https://arxiv.org/abs/1912.11370).\n",
+        "This colab accompanies our [the TensorFlow blog post](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html) and is based on the [BigTransfer paper](https://arxiv.org/abs/1912.11370).\n",
         "\n",
-        "Our models can be [found on TensorFlow Hub here](https://tfhub.dev/google/collections/bit/1). We also share code to fine-tune our models in TensorFlow2, JAX and PyTorch in [our GitHub repository](https://github.com/google-research/big_transfer).\n"
+        "Our models can be [found on TensorFlow Hub here](https://tfhub.dev/google/collections/bit/1). We also share code to fine-tune our models in TensorFlow2, JAX and PyTorch in [our GitHub repository](https://github.com/google-research/big_transfer).\n",
+        "Additional models obtained by finetuning BiT-m in subdomains can be found [here](https://tfhub.dev/google/collections/experts/bit/1).\n"
+
       ]
     },
     {
@@ -702,7 +704,7 @@
         "# Import tf_flowers data from tfds\n",
         "\n",
         "dataset_name = 'tf_flowers'\n",
-        "ds, info = tfds.load(name=dataset_name, split=['train'], in_memory=False, with_info=True)\n",
+        "ds, info = tfds.load(name=dataset_name, split=['train'], with_info=True)\n",
         "ds = ds[0]\n",
         "num_examples = info.splits['train'].num_examples\n",
         "NUM_CLASSES = 5"

--- a/colabs/big_transfer_tf2.ipynb
+++ b/colabs/big_transfer_tf2.ipynb
@@ -323,11 +323,10 @@
         "\n",
         "In this colab, we will show you how to load one of our BiT models (a ResNet50 trained on ImageNet-21k), use it out-of-the-box and fine-tune it on a dataset of flowers.\n",
         "\n",
-        "This colab accompanies our [the TensorFlow blog post](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html) and is based on the [BigTransfer paper](https://arxiv.org/abs/1912.11370).\n",
+        "This colab accompanies our [TensorFlow blog post](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html) and is based on the [BigTransfer paper](https://arxiv.org/abs/1912.11370).\n",
         "\n",
-        "Our models can be [found on TensorFlow Hub here](https://tfhub.dev/google/collections/bit/1). We also share code to fine-tune our models in TensorFlow2, JAX and PyTorch in [our GitHub repository](https://github.com/google-research/big_transfer).\n",
-        "Additional models obtained by finetuning BiT-m in subdomains can be found [here](https://tfhub.dev/google/collections/experts/bit/1).\n"
-
+        "The models from the paper can be found on [TensorFlow Hub](https://tfhub.dev/google/collections/bit/1) and additional models obtained by finetuning BiT-m in more specific sets of data can be found [here](https://tfhub.dev/google/collections/experts/bit/1).\n",
+        "We also share code to fine-tune our models in TensorFlow2, JAX and PyTorch in [our GitHub repository](https://github.com/google-research/big_transfer).\n"
       ]
     },
     {


### PR DESCRIPTION
 - Updates links to blogpost and more models.
 - Fixes use of deprecated in_memory.